### PR TITLE
Feature/bump version with upgraded dependencies

### DIFF
--- a/climate_watch_engine/climate_watch_engine.gemspec
+++ b/climate_watch_engine/climate_watch_engine.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency 'aws-sdk', '~> 2'
+  s.add_dependency 'aws-sdk-s3', '~> 1'
   s.add_dependency 'rails', '~> 5.2.0'
 end

--- a/climate_watch_engine/lib/climate_watch_engine/version.rb
+++ b/climate_watch_engine/lib/climate_watch_engine/version.rb
@@ -1,3 +1,3 @@
 module ClimateWatchEngine
-  VERSION = '1.2.1'.freeze
+  VERSION = '1.3.0'.freeze
 end

--- a/historical_emissions/historical_emissions.gemspec
+++ b/historical_emissions/historical_emissions.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |s|
                 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   s.add_dependency 'active_model_serializers', '~> 0.10.0'
-  s.add_dependency 'aws-sdk', '~> 2'
-  s.add_dependency 'climate_watch_engine', '~> 1.2.0'
-  s.add_dependency 'cw_locations', '~> 1.2.0'
+  s.add_dependency 'aws-sdk-s3', '~> 1'
+  s.add_dependency 'climate_watch_engine', '~> 1.3.0'
+  s.add_dependency 'cw_locations', '~> 1.3.0'
   s.add_dependency 'pg'
   s.add_dependency 'rails', '~> 5.2.0'
 

--- a/historical_emissions/lib/historical_emissions/engine.rb
+++ b/historical_emissions/lib/historical_emissions/engine.rb
@@ -1,5 +1,5 @@
 require 'active_model_serializers'
-require 'aws-sdk'
+require 'aws-sdk-s3'
 require 'locations/engine'
 
 module HistoricalEmissions

--- a/historical_emissions/lib/historical_emissions/version.rb
+++ b/historical_emissions/lib/historical_emissions/version.rb
@@ -1,3 +1,3 @@
 module HistoricalEmissions
-  VERSION = '1.2.1'.freeze
+  VERSION = '1.3.0'.freeze
 end

--- a/locations/lib/locations/engine.rb
+++ b/locations/lib/locations/engine.rb
@@ -1,5 +1,5 @@
 require 'active_model_serializers'
-require 'aws-sdk'
+require 'aws-sdk-s3'
 
 module Locations
   class Engine < ::Rails::Engine

--- a/locations/lib/locations/version.rb
+++ b/locations/lib/locations/version.rb
@@ -1,3 +1,3 @@
 module Locations
-  VERSION = '1.2.2'.freeze
+  VERSION = '1.3.0'.freeze
 end

--- a/locations/locations.gemspec
+++ b/locations/locations.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
                 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   s.add_dependency 'active_model_serializers', '~> 0.10.0'
-  s.add_dependency 'aws-sdk', '~> 2'
-  s.add_dependency 'climate_watch_engine', '~> 1.2.0'
+  s.add_dependency 'aws-sdk-s3', '~> 1'
+  s.add_dependency 'climate_watch_engine', '~> 1.3.0'
   s.add_dependency 'rails', '~> 5.2.0'
   s.add_dependency 'pg'
 


### PR DESCRIPTION
We need to upgrade aws-sdk in all gems in order to make it possible to use them together with the data_uploader gem in same application.