### PR TITLE
Add hard space converter to s3csvreader

### DIFF
--- a/climate_watch_engine/app/services/s3_csv_reader.rb
+++ b/climate_watch_engine/app/services/s3_csv_reader.rb
@@ -8,7 +8,7 @@ module S3CSVReader
   end
 
   # @param header_converter [Symbol] default :symbol
-  def self.read(filename, header_converters = :symbol)
+  def self.read(filename, header_converters: :symbol)
     bucket_name = ClimateWatchEngine.s3_bucket_name
     s3 = Aws::S3::Client.new
 

--- a/climate_watch_engine/lib/climate_watch_engine/version.rb
+++ b/climate_watch_engine/lib/climate_watch_engine/version.rb
@@ -1,3 +1,3 @@
 module ClimateWatchEngine
-  VERSION = '1.3.2'.freeze
+  VERSION = '1.3.3'.freeze
 end


### PR DESCRIPTION
Sometimes we have hard spaces in CSV file (character code 160) and strip does not work with hard spaces so we should convert them into normal spaces.