### PR TITLE
[Emissions] Fix parsing emission value

### DIFF
--- a/historical_emissions/app/services/import_historical_emissions.rb
+++ b/historical_emissions/app/services/import_historical_emissions.rb
@@ -39,7 +39,7 @@ class ImportHistoricalEmissions
 
   def emissions(row)
     row.headers.grep(/\d{4}/).map do |year|
-      {year: year.to_s.to_i, value: row[year]&.to_f}
+      {year: year.to_s.to_i, value: row[year]&.delete(',')&.to_f}
     end
   end
 

--- a/historical_emissions/lib/historical_emissions/version.rb
+++ b/historical_emissions/lib/historical_emissions/version.rb
@@ -1,3 +1,3 @@
 module HistoricalEmissions
-  VERSION = '1.3.2'.freeze
+  VERSION = '1.3.3'.freeze
 end


### PR DESCRIPTION
I found a problem with parsing emission value when the value is saved in CSV file as text with thousands separator eg. `103,230`. We have to remove all commas before converting to float, otherwise the saved value would be as in mentioned example `100`.

So, the problem was found for indonesia platform, location: ID.BA, sector: Total, the API response is:
![screenshot from 2018-11-22 14-09-28](https://user-images.githubusercontent.com/1286444/48905511-0ef5de00-ee62-11e8-9e83-a77100bb5cfc.png)

but the values in CSV
![screenshot from 2018-11-22 14-10-24](https://user-images.githubusercontent.com/1286444/48905532-19b07300-ee62-11e8-8f3b-72e7c60485bc.png)

Here is the branch where the fix can be tested after importing data once again: https://github.com/ClimateWatch-Vizzuality/indonesia-platform/tree/update_cw_gems