### PR TITLE
Enables actually removing obsolete bits

### DIFF
--- a/data_uploader/app/models/data_uploader/section.rb
+++ b/data_uploader/app/models/data_uploader/section.rb
@@ -2,8 +2,8 @@ module DataUploader
   class Section < ApplicationRecord
     self.table_name = 'sections'
     belongs_to :platform, class_name: 'DataUploader::Platform'
-    has_many :datasets, class_name: 'DataUploader::Dataset'
-    has_many :worker_logs, class_name: 'DataUploader::WorkerLog'
+    has_many :datasets, class_name: 'DataUploader::Dataset', dependent: :destroy
+    has_many :worker_logs, class_name: 'DataUploader::WorkerLog', dependent: :destroy
     validates :name, presence: true
   end
 end

--- a/data_uploader/lib/data_uploader/version.rb
+++ b/data_uploader/lib/data_uploader/version.rb
@@ -1,3 +1,3 @@
 module DataUploader
-  VERSION = '0.3.5'
+  VERSION = '0.3.6'
 end


### PR DESCRIPTION
When trying to update the structure on one of the apps, the boilerplate task was failing because the removal of obsolete sections was not cascading.

This sorts this issue. But do let me know if there was a reason not to do this! =)

Thanks!