### PR TITLE
Show filename when error on loading csv file

### DIFF
--- a/climate_watch_engine/app/services/s3_csv_reader.rb
+++ b/climate_watch_engine/app/services/s3_csv_reader.rb
@@ -5,13 +5,6 @@ class S3CSVReader
 
   FileLoadingError = Class.new(StandardError)
 
-  attr_reader :s3, :bucket
-
-  def initialize
-    @s3 = Aws::S3::Client.new
-    @bucket = ClimateWatchEngine.s3_bucket_name
-  end
-
   class << self
     delegate :read, to: :instance
   end
@@ -30,9 +23,11 @@ class S3CSVReader
   private
 
   def get_file(filename)
+    s3 = Aws::S3::Client.new
+    bucket = ClimateWatchEngine.s3_bucket_name
     s3.get_object(bucket: bucket, key: filename)
   rescue Aws::S3::Errors::NoSuchKey
-    Rails.logger.error "File #{filename} not found in #{bucket_name}"
+    Rails.logger.error "File #{filename} not found in #{bucket}"
   end
 
   def parse(file, header_converters)

--- a/climate_watch_engine/lib/climate_watch_engine/version.rb
+++ b/climate_watch_engine/lib/climate_watch_engine/version.rb
@@ -1,3 +1,3 @@
 module ClimateWatchEngine
-  VERSION = '1.3.3'.freeze
+  VERSION = '1.3.4'.freeze
 end


### PR DESCRIPTION
We want to show filename in worker logs when there was an error on loading.
![image](https://user-images.githubusercontent.com/1286444/49172391-3b699880-f341-11e8-9fc2-4bde8c5478ef.png)

Story: https://www.pivotaltracker.com/story/show/161808190

Branch when you can test it on Indonesia platform: https://github.com/ClimateWatch-Vizzuality/indonesia-platform/tree/fix/import-data-sources

I think it would be great to also show which records were not loaded, how many were loaded correctly etc. Although, that would require to change all importers as well.