### PR TITLE
deeply_nested_sectors parameter for historical_emissions endpoint

### DIFF
--- a/historical_emissions/app/controllers/historical_emissions/historical_emissions_controller.rb
+++ b/historical_emissions/app/controllers/historical_emissions/historical_emissions_controller.rb
@@ -23,10 +23,10 @@ module HistoricalEmissions
 
       respond_to do |format|
         format.json do
-          values = ::HistoricalEmissions::Record.find_by_params(params)
+          values = ::HistoricalEmissions::Record.find_by_params(index_params)
           render json: values,
                  each_serializer: ::HistoricalEmissions::RecordSerializer,
-                 params: params
+                 params: index_params
         end
 
         format.csv do
@@ -44,7 +44,7 @@ module HistoricalEmissions
       render(
         json: HistoricalEmissionsMetadata.new(
           merged_records(grouped_records),
-          ::HistoricalEmissions::Sector.all,
+          fetch_meta_sectors,
           ::HistoricalEmissions::Gas.all,
           ::HistoricalEmissions::Gwp.all,
           Location.all
@@ -55,10 +55,29 @@ module HistoricalEmissions
 
     private
 
+    def fetch_meta_sectors
+      return ::HistoricalEmissions::Sector.all if deeply_nested_sectors?
+
+      ::HistoricalEmissions::Sector.first_and_second_level
+    end
+
+    def index_params
+      return params if deeply_nested_sectors?
+
+      not_deeply_nested_ids = ::HistoricalEmissions::Sector.first_and_second_level.pluck(:id)
+      sector_ids = (params[:sector] || '').split(',') | not_deeply_nested_ids
+
+      params.merge(sector: sector_ids.join(','))
+    end
+
     def valid_params(params)
       params[:source] && (
         params[:location] || params[:sector] || params[:gas]
       )
+    end
+
+    def deeply_nested_sectors?
+      params.fetch(:deeply_nested_sectors, 'true') == 'true'
     end
 
     def grouped_records

--- a/historical_emissions/app/models/historical_emissions/sector.rb
+++ b/historical_emissions/app/models/historical_emissions/sector.rb
@@ -6,5 +6,13 @@ module HistoricalEmissions
                         required: false
     has_many :records, class_name: 'HistoricalEmissions::Record'
     validates :name, presence: true
+
+    def self.first_and_second_level
+      joins('LEFT JOIN historical_emissions_sectors parents ON historical_emissions_sectors.parent_id = parents.id').
+        where('
+          parents.parent_id IS NULL OR
+          historical_emissions_sectors.parent_id IS NULL
+        ')
+    end
   end
 end

--- a/historical_emissions/lib/historical_emissions/version.rb
+++ b/historical_emissions/lib/historical_emissions/version.rb
@@ -1,3 +1,3 @@
 module HistoricalEmissions
-  VERSION = '1.4.0'.freeze
+  VERSION = '1.5.0'.freeze
 end


### PR DESCRIPTION
New `deeply_nested_sectors` parameter for historical_emissions `emissions` and `emissions/meta` endpoints. Default value is `true`.

You can test the endpoint on SA platform here: https://github.com/ClimateWatch-Vizzuality/south-africa-platform/tree/deeply_nested_sectors

I wasn't sure if metadata needs to be filtered too, but it is.