### PR TITLE
Adds a new mime type for CSV

### DIFF
--- a/data_uploader/app/admin/data_uploader/use_case/upload_datafile.rb
+++ b/data_uploader/app/admin/data_uploader/use_case/upload_datafile.rb
@@ -27,6 +27,7 @@ module DataUploader
 
       def validate_content_type_against_csv(params, callbacks)
         permitted_mime_types = ['text/csv', 'text/comma-separated-values',
+                                'application/vnd.ms-excel',
                                 'application/csv', 'text/plain']
         return if permitted_mime_types.include?(params[:datafile].content_type)
         callbacks[:datafile_wrong_content_type].call

--- a/data_uploader/lib/data_uploader/version.rb
+++ b/data_uploader/lib/data_uploader/version.rb
@@ -1,3 +1,3 @@
 module DataUploader
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end


### PR DESCRIPTION
I was just showing the Data Uploader to Katie and when she tried to upload a file from her machine she was getting a "file is not a csv" error... Looking at the logs while she was doing it seems that her file was actually `application/vnd.ms-excel`

```
Parameters: {"utf8"=>"✓", "authenticity_token"=>"7LF7zLd5IyTGxwTiF1Y89kxLmWATIAVXvV5HyGwFYzBrnigWE8Ll0omDMEydPJRcodz70rULKbAf5vCerFwh0g==", "datafile"=>#<ActionDispatch::Http::UploadedFile:0x00007f426c45a500 @tempfile=#<Tempfile:/tmp/RackMultipart20181206-1-1aretsj.csv>, @original_filename="NDC_INDC.csv", @content_type="application/vnd.ms-excel", @headers="Content-Disposition: form-data; name=\"datafile\"; filename=\"NDC_INDC.csv\"\r\nContent-Type: application/vnd.ms-excel\r\n">, "commit"=>"Upload file", "dataset_id"=>"30"}
```