### PR TITLE
importing row: catch and report all errors not only active record invalid

### DIFF
--- a/climate_watch_engine/app/services/concerns/climate_watch_engine/csv_importer.rb
+++ b/climate_watch_engine/app/services/concerns/climate_watch_engine/csv_importer.rb
@@ -42,9 +42,9 @@ module ClimateWatchEngine
 
     def with_logging(filepath, row_index)
       yield
-    rescue ActiveRecord::RecordInvalid => invalid
+    rescue StandardError => error
       filename = File.basename(filepath)
-      msg = "#{filename}: Error importing row #{row_index}: #{invalid}"
+      msg = "#{filename}: Error importing row #{row_index}: #{error}"
       STDERR.puts msg
       add_error(:invalid_row, msg: msg, row: row_index, filename: filename)
     end

--- a/climate_watch_engine/lib/climate_watch_engine/version.rb
+++ b/climate_watch_engine/lib/climate_watch_engine/version.rb
@@ -1,3 +1,3 @@
 module ClimateWatchEngine
-  VERSION = '1.4.2'.freeze
+  VERSION = '1.4.3'.freeze
 end


### PR DESCRIPTION
More things could go wrong when importing and then we don't want to lose info in which row it happened.