### PR TITLE
Adds guards to new migration on data uploader

### DIFF
--- a/data_uploader/db/migrate/20181129153835_add_details_to_worker_logs.rb
+++ b/data_uploader/db/migrate/20181129153835_add_details_to_worker_logs.rb
@@ -1,10 +1,14 @@
 class AddDetailsToWorkerLogs < ActiveRecord::Migration[5.2]
   def up
-    add_column :worker_logs, :details, :jsonb, default: {}
-    DataUploader::WorkerLog.find_each do |log|
-      log.update!(details: { errors: [{ type: :error, msg: log.error }] })
+    unless column_exists? :worker_logs, :details
+      add_column :worker_logs, :details, :jsonb, default: {}
+      DataUploader::WorkerLog.find_each do |log|
+        log.update!(details: { errors: [{ type: :error, msg: log.error }] })
+      end
     end
-    remove_column :worker_logs, :error
+    if column_exists? :worker_logs, :error
+      remove_column :worker_logs, :error
+    end
   end
 
   def down


### PR DESCRIPTION
Today while making some changes to the data_uploader installation on Climate Watch I realised that my database didn't have the necessary fields on the worker_logs so I pulled the migrations from the gem and ran them locally. It was all nice and good... until I deployed, and the migrations didn't run on staging.

This happens because we are using a shared database across a few tools on staging, and the columns already exists. I've added this to this specific migration, but maybe we'd need to add this kind of checks throughout?

Or am I seeing things wrongly? Would love to hear your thoughts!