### PR TITLE
Allow sections without datasets

### DIFF
--- a/data_uploader/lib/data_uploader/version.rb
+++ b/data_uploader/lib/data_uploader/version.rb
@@ -1,3 +1,3 @@
 module DataUploader
-  VERSION = '0.4.4'
+  VERSION = '0.4.5'.freeze
 end

--- a/data_uploader/lib/tasks/datasets.rake
+++ b/data_uploader/lib/tasks/datasets.rake
@@ -11,7 +11,7 @@ namespace :db do
 
         platform_props['sections'].each do |section_props|
           section = platform.sections.find_by(name: section_props['name'])
-          next unless section
+          next unless section && section_props['datasets']
 
           dataset_names = section_props['datasets']
           dataset_names.each do |dataset_name|
@@ -44,10 +44,12 @@ namespace :db do
           section_name = section_props['name']
           next unless old_names[platform_name][section_name]
 
-          section_props['datasets'].each do |dataset_name|
-            next unless old_names[platform_name][section_name].find(dataset_name)
+          if section_props['datasets']
+            section_props['datasets'].each do |dataset_name|
+              next unless old_names[platform_name][section_name].find(dataset_name)
 
-            old_names[platform_name][section_name].delete(dataset_name)
+              old_names[platform_name][section_name].delete(dataset_name)
+            end
           end
 
           datasets = DataUploader::Dataset.


### PR DESCRIPTION
We have a new use case on Climate Watch where we need to add a section without any datasets, this was not possible without this change.

Hopefully this won't break anything! =)