### PR TITLE
Abort importer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 env:
   global:
     - CC_TEST_REPORTER_ID=c4f24e94293203e5b662a4c20e1a872354f69511b0c7ba63f2980e5c5dbd25b2
-dist: trusty
-sudo: false
+dist: bionic
 language: ruby
 rvm:
 - 2.5.1

--- a/data_uploader/app/controllers/concerns/data_uploader/shared_admin.rb
+++ b/data_uploader/app/controllers/concerns/data_uploader/shared_admin.rb
@@ -77,6 +77,18 @@ module DataUploader
 
         redirect_to path, notice: notice
       end
+
+      base.send(:page_action, :abort_importer, method: :patch) do
+        worker_log = DataUploader::WorkerLog.find_by_id(params[:id])
+        if worker_log
+          # if the job has not been started yet, we might still be able to cancel it
+          DataUploader::BaseImportWorker.cancel!(worker_log.jid)
+          worker_log.update(state: 'aborted')
+        end
+        notice = 'Task aborted.'
+
+        redirect_to path, notice: notice
+      end
     end
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/AbcSize

--- a/data_uploader/app/models/data_uploader/worker_log.rb
+++ b/data_uploader/app/models/data_uploader/worker_log.rb
@@ -7,7 +7,8 @@ module DataUploader
       started: 1,
       finished: 2,
       failed: 3,
-      dead: 4
+      dead: 4,
+      aborted: 5
     }
 
     def details_errors

--- a/data_uploader/app/services/templates/admin_controller_template.rb.erb
+++ b/data_uploader/app/services/templates/admin_controller_template.rb.erb
@@ -64,6 +64,7 @@ ActiveAdmin.register_page '<%= "#{@platform.titleize} #{@section.titleize}" %>' 
       download_single_data_file_path:
           admin_<%= @platform %>_<%= @section %>_download_datafile_path,
       import_path: admin_<%= @platform %>_<%= @section %>_run_importer_path,
+      abort_path: admin_<%= @platform %>_<%= @section %>_abort_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/data_uploader/app/views/data_uploader/admin/_form_upload_datasets.html.erb
+++ b/data_uploader/app/views/data_uploader/admin/_form_upload_datasets.html.erb
@@ -62,6 +62,7 @@
         <th class="col" style="width:10%">Status</th>
         <th class="col" style="width:50%">Details</th>
         <th class="col" style="width:20%">Admin user</th>
+        <th class="col" style="width:20%">Action</th>
       </thead>
       <tbody>
         <% logs.each do |log| %>
@@ -78,6 +79,12 @@
               <% end %>
             </td>
             <td><%= log.user_email %></td>
+
+            <td>
+              <% if defined?(abort_path) && log.state == 'started' %>
+                <%= link_to 'Abort', abort_path + "?id=#{log.id}", method: :patch %>
+              <% end %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/data_uploader/lib/data_uploader/version.rb
+++ b/data_uploader/lib/data_uploader/version.rb
@@ -1,3 +1,3 @@
 module DataUploader
-  VERSION = '0.4.5'.freeze
+  VERSION = '0.5.0'.freeze
 end


### PR DESCRIPTION
Implements the ability to abort a stalled importer (one that gets stuck in "started" state forever)