### PR TITLE
Removed logic to cancel sidekiq jobs

### DIFF
--- a/data_uploader/app/controllers/concerns/data_uploader/shared_admin.rb
+++ b/data_uploader/app/controllers/concerns/data_uploader/shared_admin.rb
@@ -81,8 +81,6 @@ module DataUploader
       base.send(:page_action, :abort_importer, method: :patch) do
         worker_log = DataUploader::WorkerLog.find_by_id(params[:id])
         if worker_log
-          # if the job has not been started yet, we might still be able to cancel it
-          DataUploader::BaseImportWorker.cancel!(worker_log.jid)
           worker_log.update(state: 'aborted')
         end
         notice = 'Task aborted.'

--- a/data_uploader/app/workers/data_uploader/base_import_worker.rb
+++ b/data_uploader/app/workers/data_uploader/base_import_worker.rb
@@ -6,8 +6,6 @@ module DataUploader
     sidekiq_options queue: :database, retry: false
 
     def perform(section_id, importer_class_name, admin)
-      return if cancelled?
-
       section = DataUploader::Section.find(section_id)
       importer = importer_class_name.constantize.new
 
@@ -25,14 +23,6 @@ module DataUploader
 
     def job_in_progress?(section)
       section.worker_logs.started.any?
-    end
-
-    def cancelled?
-      Sidekiq.redis {|c| c.exists?("cancelled-#{jid}") } # Use c.exists? on Redis >= 4.2.0
-    end
-
-    def self.cancel!(jid)
-      Sidekiq.redis {|c| c.setex("cancelled-#{jid}", 86400, 1) }
     end
   end
 end

--- a/data_uploader/data_uploader.gemspec
+++ b/data_uploader/data_uploader.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'aws-sdk-s3', '~> 1'
 
   s.add_dependency 'rubyzip'
-  s.add_dependency 'sidekiq'
+  s.add_dependency 'sidekiq', '>= 6.1.0'
 
   s.add_dependency 'climate_watch_engine', '~> 1.4.0'
 

--- a/data_uploader/lib/data_uploader/version.rb
+++ b/data_uploader/lib/data_uploader/version.rb
@@ -1,3 +1,3 @@
 module DataUploader
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.5.1'.freeze
 end


### PR DESCRIPTION
Removed logic to cancel sidekiq jobs, because I have no patience dealing with redis versions and anyway the advantage was insignificant (if the job was already running, it would not get cancelled anyway)